### PR TITLE
fix: error message

### DIFF
--- a/lib/whats/client.rb
+++ b/lib/whats/client.rb
@@ -100,7 +100,7 @@ module Whats
       unless response.is_a?(Net::HTTPSuccess)
         err = response.content_type == "application/json" ? response.body : ""
 
-        raise Whats::Errors::RequestError.new("API request error.", err)
+        raise Whats::Errors::RequestError.new("API request error.", JSON.parse(err))
       end
 
       parse_response(response)
@@ -119,11 +119,9 @@ module Whats
     end
 
     def parse_json_response(response)
-      begin
-        JSON.parse(response.body)
-      rescue JSON::ParserError => e
-        raise Whats::Errors::ParseError, "JSON parsing error: #{e.message}"
-      end
+      JSON.parse(response.body)
+    rescue JSON::ParserError => e
+      raise Whats::Errors::ParseError, "JSON parsing error: #{e.message}"
     end
 
     def download_media(response, content_type)


### PR DESCRIPTION
**CHANGELOG** :memo:

* When we got an error we'll have a string and not a JSON, for this reason is necessary to use `JSON.parse(response)`
