### PR TITLE
feat: update WhatsApp API to v23.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    whatsapp (1.3.1)
+    whatsapp (1.4.6)
       mime-types (~> 3.3)
       multipart-post (~> 2.4)
       net-http (~> 0.4)
@@ -118,6 +118,7 @@ GEM
     zeitwerk (2.6.13)
 
 PLATFORMS
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/whats/actions/get_media.rb
+++ b/lib/whats/actions/get_media.rb
@@ -3,7 +3,7 @@ module Whats
     class GetMedia
       attr_reader :client, :path
 
-      ENDPOINT = "/v18.0/%{media_id}"
+      ENDPOINT = "/v23.0/%{media_id}"
 
       def initialize(client, media_id)
         @client = client

--- a/lib/whats/actions/mark_read.rb
+++ b/lib/whats/actions/mark_read.rb
@@ -3,7 +3,7 @@
 module Whats
   module Actions
     class MarkRead
-      ENDPOINT = "/v17.0/%{phone_id}/messages"
+      ENDPOINT = "/v23.0/%{phone_id}/messages"
 
       def initialize(client, message_id, phone_id)
         @client = client

--- a/lib/whats/actions/send_message.rb
+++ b/lib/whats/actions/send_message.rb
@@ -3,7 +3,7 @@
 module Whats
   module Actions
     class SendMessage
-      ENDPOINT = "/v17.0/%{phone_id}/messages"
+      ENDPOINT = "/v23.0/%{phone_id}/messages"
 
       COMMON_PAYLOAD = {
         messaging_product: 'whatsapp',

--- a/lib/whats/actions/templates/create.rb
+++ b/lib/whats/actions/templates/create.rb
@@ -11,7 +11,7 @@ module Whats
         attr_reader :client, :path
         attr_accessor :name, :category, :allow_category_change, :language, :components
 
-        ENDPOINT = "/v17.0/%{waba_id}/message_templates"
+        ENDPOINT = "/v23.0/%{waba_id}/message_templates"
         AVAILABLE_CATEGORIES = %w[AUTHENTICATION MARKETING UTILITY]
         AVAILABLE_LANGUAGE_CODES = %w[
           af sq ar az bn bg ca zh_CN zh_HK zh_TW hr cs da nl en en_GB en_US et fil fi fr ka de el gu ha he hi hu id ga it

--- a/lib/whats/actions/templates/delete.rb
+++ b/lib/whats/actions/templates/delete.rb
@@ -6,7 +6,7 @@ module Whats
 
         attr_reader :client, :template_name
 
-        ENDPOINT = "/v17.0/%{waba_id}/message_templates?name=%{template_name}"
+        ENDPOINT = "/v23.0/%{waba_id}/message_templates?name=%{template_name}"
 
         validates :template_name, presence: true
 

--- a/lib/whats/actions/templates/update.rb
+++ b/lib/whats/actions/templates/update.rb
@@ -11,7 +11,7 @@ module Whats
         attr_accessor :category, :components
         attr_reader :client, :path
 
-        ENDPOINT = "/v17.0/%{template_id}"
+        ENDPOINT = "/v23.0/%{template_id}"
 
         validates :category, inclusion: { in: Create::AVAILABLE_CATEGORIES }, allow_nil: true
         validates :components, length: { minimum: 1 }, allow_nil: true

--- a/lib/whats/actions/upload_media.rb
+++ b/lib/whats/actions/upload_media.rb
@@ -3,7 +3,7 @@ module Whats
     class UploadMedia
       attr_reader :client, :file_path, :type, :path
 
-      ENDPOINT = "/v18.0/%{phone_number_id}/media"
+      ENDPOINT = "/v23.0/%{phone_number_id}/media"
 
       def initialize(client, phone_number_id, file_path, type)
         @client = client

--- a/lib/whats/services/app/retrieve_media.rb
+++ b/lib/whats/services/app/retrieve_media.rb
@@ -2,7 +2,7 @@ module App
   class RetrieveMedia
     attr_reader :file, :client, :path, :content_type
 
-   ENDPOINT = "/v18.0/%{upload_id}"
+   ENDPOINT = "/v23.0/%{upload_id}"
 
     def initialize(client, file, upload_id, content_type)
       @client = client

--- a/lib/whats/services/app/upload_session.rb
+++ b/lib/whats/services/app/upload_session.rb
@@ -2,7 +2,7 @@ module App
   class UploadSession
     attr_reader :client, :file_length, :file_type, :file_name
 
-    ENDPOINT = "/v18.0/app/uploads/?file_length=%{file_length}&file_type=%{file_type}&file_name=%{file_name}"
+    ENDPOINT = "/v23.0/app/uploads/?file_length=%{file_length}&file_type=%{file_type}&file_name=%{file_name}"
     ACCEPTED_FILE_TYPES = ["image", "jpeg", "jpg", "png"]
 
     def initialize(client, file_length, file_type, file_name)

--- a/lib/whats/version.rb
+++ b/lib/whats/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Whats
-  VERSION = "1.4.5"
+  VERSION = "1.4.6"
 end


### PR DESCRIPTION
**CHANGELOG** :memo:
> [!NOTE]
> This pull request updates the WhatsApp API version used across the codebase from various older versions (v17.0 and v18.0) to v23.0 for all relevant endpoints. This ensures compatibility with the latest API features and requirements. Additionally, the gem version is incremented to reflect these changes.

**API Endpoint Version Updates:**

* Updated all WhatsApp API endpoint constants in action classes to use v23.0 instead of previous versions, including `SendMessage`, `MarkRead`, `GetMedia`, `UploadMedia`, and all template-related actions (`Create`, `Delete`, `Update`). [[1]](diffhunk://#diff-356a2f2a5ed66bfee4380aa333af829dbe5982cd2394396e9e2b4c0a324479f5L6-R6) [[2]](diffhunk://#diff-7d3573a27b085c4198feaf37a7cd9a3162f2128c6f0257f016337946b1cf87a4L6-R6) [[3]](diffhunk://#diff-dbdcf4f648ab9d9b996987bad8a0cdaaea603bee5d87f22ef402d653edd79b94L6-R6) [[4]](diffhunk://#diff-0268f79a56bd293b1d1465f464e5db8a3d7b621cac3c08bff68ffac4a6eee74fL6-R6) [[5]](diffhunk://#diff-0d0a53ddbf1671249c157b444c6c3adad49c77b9bb9690e77931128c7dcb79cdL14-R14) [[6]](diffhunk://#diff-7c24cffcb23fdd178e3b58a6e4ceb5549946d770aa074ee1d0d8d8d11ed80b7bL9-R9) [[7]](diffhunk://#diff-742a1ed3f277f11d934d9c39325b43b4a401ae07d7f9ce87430f0cbcfa4daee6L14-R14)
* Updated service classes to use v23.0 endpoints for media retrieval and upload sessions (`RetrieveMedia`, `UploadSession`). [[1]](diffhunk://#diff-bd2fbb555d0713bdf436e44627f8071947d9eeef3dfda81a0584e53470a67730L5-R5) [[2]](diffhunk://#diff-e840fdc50e0bed4211f26850bb3fc9c2edd646c4b844756dc2fd55d46b55dcf5L5-R5)

**Version Bump:**

* Incremented the gem version from `1.4.5` to `1.4.6` in `lib/whats/version.rb` to reflect the API upgrade.
